### PR TITLE
Fixed functions and optimizing

### DIFF
--- a/README-pt.md
+++ b/README-pt.md
@@ -19,15 +19,12 @@ Uma include para **Pawn** que permite detectar se um jogador está olhando para 
 ## ⚙️ Funções Nativas
 
 ```pawn
-native GetPlayerViewDirection(playerid, Float:scale, &Float:x, &Float:y, &Float:z);
-
-native bool:IsFloatBetween(Float:value, Float:center, Float:range = 2.0);
-native bool:IsPointLookingAtPoint(playerid, Float:x, Float:y, Float:z);
-native bool:IsPlayerLookingAtPlayer(playerid, targetid, Float:range = 2.0);
-native bool:IsPlayerLookingAtVehicle(playerid, vehicleid);
-native bool:IsPlayerLookingAtObject(playerid, objectid);
-native bool:IsPlayerLookingAtActor(playerid, actorid);
-native bool:IsLookingAtEntity(playerid, entityType, entityID, Float:range = 2.0);
+native bool:IsPointLookingAtPoint(playerid, Float:x, Float:y, Float:z, Float:range = MAX_RANGE_DISTANCE);
+native bool:IsPlayerLookingAtPlayer(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
+native bool:IsPlayerLookingAtVehicle(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
+native bool:IsPlayerLookingAtObject(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
+native bool:IsPlayerLookingAtActor(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
+native bool:IsPlayerLookingAt(playerid, E_LOOKAT_TYPE:type, targetid, Float:range = MAX_RANGE_DISTANCE);
 ```
 
 > \[!IMPORTANTE]
@@ -41,27 +38,33 @@ native bool:IsLookingAtEntity(playerid, entityType, entityID, Float:range = 2.0)
 
 | ID | Tipo    |
 | -- | ------- |
-| 1  | Player  |
-| 2  | Veículo |
-| 3  | Objeto  |
-| 4  | Actor   |
+| E_LOOKAT_PLAYER   | Player  |
+| E_LOOKAT_VEHICLE  | Vehicle |
+| E_LOOKAT_OBJECT   | Object  |
+| E_LOOKAT_ACTOR    | Actor   |
 
 ---
 
 ## 🧪 Exemplo de Uso
 
 ```pawn
-CMD:interagir(playerid)
+CMD:interact(playerid)
 {
-    for (new i = 0; i < MAX_PLAYERS; i++)
-    {
+    for (new i = 0; i < MAX_PLAYERS; i++) {
+		if(!IsPlayerConnected(i)) continue;
+
         if (i != playerid && IsPlayerLookingAtPlayer(playerid, i)) {
             SendClientMessage(playerid, -1, "Voce esta olhando para um jogador!");
         } 
-        else if (IsPlayerLookingAtVehicle(playerid, i)) {
+    }
+
+	for (new i = 0; i < MAX_VEHICLES; i++) {
+		if(!IsValidVehicle(i)) continue;
+
+		if (IsPlayerLookingAtVehicle(playerid, i)) {
 			SendClientMessage(playerid, -1, "Voce esta olhando para o seu veiculo!");
 		}
-    }
+	}
     return 1;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -19,15 +19,12 @@ A Pawn include for checking whether a player is looking at another entity using 
 ## ⚙️ Native Functions
 
 ```pawn
-native GetPlayerViewDirection(playerid, Float:scale, &Float:x, &Float:y, &Float:z);
-
-native bool:IsFloatBetween(Float:value, Float:center, Float:range = 2.0);
-native bool:IsPointLookingAtPoint(playerid, Float:x, Float:y, Float:z);
-native bool:IsPlayerLookingAtPlayer(playerid, targetid, Float:range = 2.0);
-native bool:IsPlayerLookingAtVehicle(playerid, vehicleid);
-native bool:IsPlayerLookingAtObject(playerid, objectid);
-native bool:IsPlayerLookingAtActor(playerid, actorid);
-native bool:IsLookingAtEntity(playerid, E_LOOKAT:entityType, entityID, Float:range = 2.0);
+native bool:IsPointLookingAtPoint(playerid, Float:x, Float:y, Float:z, Float:range = MAX_RANGE_DISTANCE);
+native bool:IsPlayerLookingAtPlayer(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
+native bool:IsPlayerLookingAtVehicle(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
+native bool:IsPlayerLookingAtObject(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
+native bool:IsPlayerLookingAtActor(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
+native bool:IsPlayerLookingAt(playerid, E_LOOKAT_TYPE:type, targetid, Float:range = MAX_RANGE_DISTANCE);
 ```
 
 > \[!IMPORTANT]
@@ -54,14 +51,20 @@ native bool:IsLookingAtEntity(playerid, E_LOOKAT:entityType, entityID, Float:ran
 CMD:interact(playerid)
 {
     for (new i = 0; i < MAX_PLAYERS; i++) {
+		if(!IsPlayerConnected(i)) continue;
 
         if (i != playerid && IsPlayerLookingAtPlayer(playerid, i)) {
             SendClientMessage(playerid, -1, "Voce esta olhando para um jogador!");
         } 
-        else if (IsPlayerLookingAtVehicle(playerid, i)) {
+    }
+
+	for (new i = 0; i < MAX_VEHICLES; i++) {
+		if(!IsValidVehicle(i)) continue;
+
+		if (IsPlayerLookingAtVehicle(playerid, i)) {
 			SendClientMessage(playerid, -1, "Voce esta olhando para o seu veiculo!");
 		}
-    }
+	}
     return 1;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ native bool:IsPlayerLookingAtPlayer(playerid, targetid, Float:range = 2.0);
 native bool:IsPlayerLookingAtVehicle(playerid, vehicleid);
 native bool:IsPlayerLookingAtObject(playerid, objectid);
 native bool:IsPlayerLookingAtActor(playerid, actorid);
-native bool:IsLookingAtEntity(playerid, entityType, entityID, Float:range = 2.0);
+native bool:IsLookingAtEntity(playerid, E_LOOKAT:entityType, entityID, Float:range = 2.0);
 ```
 
 > \[!IMPORTANT]
@@ -41,10 +41,10 @@ native bool:IsLookingAtEntity(playerid, entityType, entityID, Float:range = 2.0)
 
 | ID | Type    |
 | -- | ------- |
-| 1  | Player  |
-| 2  | Vehicle |
-| 3  | Object  |
-| 4  | Actor   |
+| E_LOOKAT_PLAYER   | Player  |
+| E_LOOKAT_VEHICLE  | Vehicle |
+| E_LOOKAT_OBJECT   | Object  |
+| E_LOOKAT_ACTOR    | Actor   |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,12 @@ A Pawn include for checking whether a player is looking at another entity using 
 ## ⚙️ Native Functions
 
 ```pawn
-native GetPlayerViewDirection(playerid, Float:scale, &Float:x, &Float:y, &Float:z);
-
-native bool:IsFloatBetween(Float:value, Float:center, Float:range = 2.0);
-native bool:IsPointLookingAtPoint(playerid, Float:x, Float:y, Float:z);
-native bool:IsPlayerLookingAtPlayer(playerid, targetid, Float:range = 2.0);
-native bool:IsPlayerLookingAtVehicle(playerid, vehicleid);
-native bool:IsPlayerLookingAtObject(playerid, objectid);
-native bool:IsPlayerLookingAtActor(playerid, actorid);
-native bool:IsLookingAtEntity(playerid, entityType, entityID, Float:range = 2.0);
+native bool:IsPointLookingAtPoint(playerid, Float:x, Float:y, Float:z, Float:range = MAX_RANGE_DISTANCE);
+native bool:IsPlayerLookingAtPlayer(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
+native bool:IsPlayerLookingAtVehicle(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
+native bool:IsPlayerLookingAtObject(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
+native bool:IsPlayerLookingAtActor(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
+native bool:IsPlayerLookingAt(playerid, E_LOOKAT_TYPE:type, targetid, Float:range = MAX_RANGE_DISTANCE);
 ```
 
 > \[!IMPORTANT]
@@ -41,10 +38,10 @@ native bool:IsLookingAtEntity(playerid, entityType, entityID, Float:range = 2.0)
 
 | ID | Type    |
 | -- | ------- |
-| 1  | Player  |
-| 2  | Vehicle |
-| 3  | Object  |
-| 4  | Actor   |
+| E_LOOKAT_PLAYER   | Player  |
+| E_LOOKAT_VEHICLE  | Vehicle |
+| E_LOOKAT_OBJECT   | Object  |
+| E_LOOKAT_ACTOR    | Actor   |
 
 ---
 
@@ -54,14 +51,20 @@ native bool:IsLookingAtEntity(playerid, entityType, entityID, Float:range = 2.0)
 CMD:interact(playerid)
 {
     for (new i = 0; i < MAX_PLAYERS; i++) {
+		if(!IsPlayerConnected(i)) continue;
 
         if (i != playerid && IsPlayerLookingAtPlayer(playerid, i)) {
             SendClientMessage(playerid, -1, "Voce esta olhando para um jogador!");
         } 
-        else if (IsPlayerLookingAtVehicle(playerid, i)) {
+    }
+
+	for (new i = 0; i < MAX_VEHICLES; i++) {
+		if(!IsValidVehicle(i)) continue;
+
+		if (IsPlayerLookingAtVehicle(playerid, i)) {
 			SendClientMessage(playerid, -1, "Voce esta olhando para o seu veiculo!");
 		}
-    }
+	}
     return 1;
 }
 ```

--- a/lookat.inc
+++ b/lookat.inc
@@ -8,12 +8,12 @@
                     8       `888   .8'     `888.       888       888       `888'       .8'     `888.  oo     .d8P 
                     o8o        `8  o88o     o8888o     o888o     o888o       `8'       o88o     o8888o 8""88888P'  
 
-        native IsPointLookingAtPoint(playerid, Float:x, Float:y, Float:z);
-        native IsPlayerLookingAtPlayer(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
-        native IsPlayerLookingAtVehicle(playerid, targetid);
-        native IsPlayerLookingAtObject(playerid, targetid);
-        native IsPlayerLookingAtActor(playerid, targetid);
-        navite IsLookingAtEntity(playerid, entityType, entityID, Float:range = MAX_RANGE_DISTANCE)
+		native bool:IsPointLookingAtPoint(playerid, Float:x, Float:y, Float:z, Float:range = MAX_RANGE_DISTANCE);
+		native bool:IsPlayerLookingAtPlayer(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
+		native bool:IsPlayerLookingAtVehicle(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
+		native bool:IsPlayerLookingAtObject(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
+		native bool:IsPlayerLookingAtActor(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
+		native bool:IsPlayerLookingAt(playerid, E_LOOKAT_TYPE:type, targetid, Float:range = MAX_RANGE_DISTANCE);
                                                                                           
 */
 
@@ -60,7 +60,7 @@ static stock GetPlayerViewDirection(playerid, Float:scale, &Float:x, &Float:y, &
     z = camZ + posZ * scale;
 }
 
-stock bool:IsFloatBetween(Float:value, Float:center, Float:range = MAX_RANGE_DISTANCE)
+static stock bool:IsFloatBetween(Float:value, Float:center, Float:range = MAX_RANGE_DISTANCE)
 {
     return (value >= (center - range) && value <= (center + range));
 }

--- a/lookat.inc
+++ b/lookat.inc
@@ -29,6 +29,14 @@
 #define                      MAX_RANGE_DISTANCE     (1.0)
 #define                      MAX_SCALE_DISTANCE     (5.0)
 
+enum E_LOOKAT {
+	E_LOOKAT_INVALID = 0,
+	E_LOOKAT_PLAYER = 1,
+	E_LOOKAT_VEHICLE = 2,
+	E_LOOKAT_OBJECT = 3,
+	E_LOOKAT_ACTOR = 4
+};
+
 
 
 /*
@@ -61,14 +69,12 @@ stock bool:IsFloatBetween(Float:value, Float:center, Float:range = MAX_RANGE_DIS
     return (value >= (center - range) && value <= (center + range));
 }
 
-stock bool:IsPointLookingAtPoint(playerid, Float:x, Float:y, Float:z)
+stock bool:IsPointLookingAtPoint(playerid, Float:x, Float:y, Float:z, Float:range = MAX_RANGE_DISTANCE)
 {
     new Float:posX, Float:posY, Float:posZ;
     GetPlayerViewDirection(playerid, MAX_SCALE_DISTANCE, posX, posY, posZ);
-    if(IsFloatBetween(posX, x) && IsFloatBetween(posY, y) && IsFloatBetween(posZ, z))
-        return true;
 
-    return false;
+    return IsFloatBetween(posX, x, range) && IsFloatBetween(posY, y, range) && IsFloatBetween(posZ, z, range);
 }
 
 stock IsPlayerLookingAtPlayer(playerid, targetid, Float:range = MAX_RANGE_DISTANCE)
@@ -79,39 +85,39 @@ stock IsPlayerLookingAtPlayer(playerid, targetid, Float:range = MAX_RANGE_DISTAN
     return bool:(IsPlayerInRangeOfPoint(targetid, range, posX, posY, posZ));
 }
 
-stock bool:IsPlayerLookingAtVehicle(playerid, targetid)
+stock bool:IsPlayerLookingAtVehicle(playerid, targetid, Float:range = MAX_RANGE_DISTANCE)
 {
     new Float:posX, Float:posY, Float:posZ;
     GetVehiclePos(targetid, posX, posY, posZ);
 
-    return IsPointLookingAtPoint(playerid, posX, posY, posZ);
+    return IsPointLookingAtPoint(playerid, posX, posY, posZ, range);
 }
 
-stock bool:IsPlayerLookingAtObject(playerid, targetid)
+stock bool:IsPlayerLookingAtObject(playerid, targetid, Float:range = MAX_RANGE_DISTANCE)
 {
     new Float:posX, Float:posY, Float:posZ;
     GetObjectPos(targetid, posX, posY, posZ);
 
-    return IsPointLookingAtPoint(playerid, posX, posY, posZ);
+    return IsPointLookingAtPoint(playerid, posX, posY, posZ, range);
 }
 
-stock bool:IsPlayerLookingAtActor(playerid, targetid)
+stock bool:IsPlayerLookingAtActor(playerid, targetid, Float:range = MAX_RANGE_DISTANCE)
 {
     new Float:posX, Float:posY, Float:posZ;
     GetActorPos(targetid, posX, posY, posZ);
 
-    return IsPointLookingAtPoint(playerid, posX, posY, posZ);
+    return IsPointLookingAtPoint(playerid, posX, posY, posZ, range);
 }
 
 //entityType: 1 = player, 2 = vehicle, 3 = object, 4 = actor.
-stock bool:IsLookingAtEntity(playerid, entityType, entityID, Float:range = MAX_RANGE_DISTANCE)
+stock bool:IsLookingAtEntity(playerid, E_LOOKAT:entityType, entityID, Float:range = MAX_RANGE_DISTANCE)
 {
     switch(entityType)
     {
-        case 1: return IsPlayerLookingAtPlayer(playerid, entityID, range);
-        case 2: return IsPlayerLookingAtVehicle(playerid, entityID);
-        case 3: return IsPlayerLookingAtObject(playerid, entityID);
-        case 4: return IsPlayerLookingAtActor(playerid, entityID);
+        case E_LOOKAT_PLAYER: return IsPlayerLookingAtPlayer(playerid, entityID, range);
+        case E_LOOKAT_VEHICLE: return IsPlayerLookingAtVehicle(playerid, entityID, range);
+        case E_LOOKAT_OBJECT: return IsPlayerLookingAtObject(playerid, entityID, range);
+        case E_LOOKAT_ACTOR: return IsPlayerLookingAtActor(playerid, entityID, range);
     }
     return false;
 }

--- a/lookat.inc
+++ b/lookat.inc
@@ -73,12 +73,12 @@ stock bool:IsPointLookingAtPoint(playerid, Float:x, Float:y, Float:z, Float:rang
     return IsFloatBetween(posX, x, range) && IsFloatBetween(posY, y, range) && IsFloatBetween(posZ, z, range);
 }
 
-stock IsPlayerLookingAtPlayer(playerid, targetid, Float:range = MAX_RANGE_DISTANCE)
+stock bool:IsPlayerLookingAtPlayer(playerid, targetid, Float:range = MAX_RANGE_DISTANCE)
 {
     new Float:posX, Float:posY, Float:posZ;
     GetPlayerViewDirection(playerid, MAX_SCALE_DISTANCE, posX, posY, posZ);
 
-    return bool:(IsPlayerInRangeOfPoint(targetid, range, posX, posY, posZ));
+    return IsPointLookingAtPoint(targetid, range, posX, posY, posZ);
 }
 
 stock bool:IsPlayerLookingAtVehicle(playerid, targetid, Float:range = MAX_RANGE_DISTANCE)

--- a/lookat.inc
+++ b/lookat.inc
@@ -51,7 +51,7 @@ enum E_LOOKAT {
 
 */
 
-stock GetPlayerViewDirection(playerid, Float:scale, &Float:x, &Float:y, &Float:z)
+static stock GetPlayerViewDirection(playerid, Float:scale, &Float:x, &Float:y, &Float:z)
 {
     new Float:camX, Float:camY, Float:camZ;
     new Float:posX, Float:posY, Float:posZ;

--- a/lookat.inc
+++ b/lookat.inc
@@ -8,15 +8,12 @@
                     8       `888   .8'     `888.       888       888       `888'       .8'     `888.  oo     .d8P 
                     o8o        `8  o88o     o8888o     o888o     o888o       `8'       o88o     o8888o 8""88888P'  
 
-
-        native GetPlayerViewDirection(playerid, Float:scale, &Float:x, &Float:y, &Float:z);
-
         native IsPointLookingAtPoint(playerid, Float:x, Float:y, Float:z);
         native IsPlayerLookingAtPlayer(playerid, targetid, Float:range = MAX_RANGE_DISTANCE);
         native IsPlayerLookingAtVehicle(playerid, targetid);
         native IsPlayerLookingAtObject(playerid, targetid);
         native IsPlayerLookingAtActor(playerid, targetid);
-        IsLookingAtEntity(playerid, entityType, entityID, Float:range = MAX_RANGE_DISTANCE)
+        navite IsLookingAtEntity(playerid, entityType, entityID, Float:range = MAX_RANGE_DISTANCE)
                                                                                           
 */
 
@@ -25,16 +22,15 @@
 #endif
 #define _lookat_included
 
-                // Definers
-#define                      MAX_RANGE_DISTANCE     (1.0)
-#define                      MAX_SCALE_DISTANCE     (5.0)
+			// Definers
+static const 		Float:MAX_RANGE_DISTANCE = 1.0;
+static const 		Float:MAX_SCALE_DISTANCE = 5.0;
 
 enum E_LOOKAT {
-	E_LOOKAT_INVALID = 0,
-	E_LOOKAT_PLAYER = 1,
-	E_LOOKAT_VEHICLE = 2,
-	E_LOOKAT_OBJECT = 3,
-	E_LOOKAT_ACTOR = 4
+	E_LOOKAT_PLAYER,
+	E_LOOKAT_VEHICLE,
+	E_LOOKAT_OBJECT,
+	E_LOOKAT_ACTOR
 };
 
 
@@ -109,15 +105,15 @@ stock bool:IsPlayerLookingAtActor(playerid, targetid, Float:range = MAX_RANGE_DI
     return IsPointLookingAtPoint(playerid, posX, posY, posZ, range);
 }
 
-//entityType: 1 = player, 2 = vehicle, 3 = object, 4 = actor.
-stock bool:IsLookingAtEntity(playerid, E_LOOKAT:entityType, entityID, Float:range = MAX_RANGE_DISTANCE)
+stock bool:IsPlayerLookingAt(playerid, E_LOOKAT_TYPE:type, targetid, Float:range = MAX_RANGE_DISTANCE)
 {
-    switch(entityType)
-    {
-        case E_LOOKAT_PLAYER: return IsPlayerLookingAtPlayer(playerid, entityID, range);
-        case E_LOOKAT_VEHICLE: return IsPlayerLookingAtVehicle(playerid, entityID, range);
-        case E_LOOKAT_OBJECT: return IsPlayerLookingAtObject(playerid, entityID, range);
-        case E_LOOKAT_ACTOR: return IsPlayerLookingAtActor(playerid, entityID, range);
+    new Float:x, Float:y, Float:z;
+    switch (type) {
+        case E_LOOKAT_PLAYER: GetPlayerPos(targetid,  x, y, z);
+        case E_LOOKAT_VEHICLE: GetVehiclePos(targetid, x, y, z);
+        case E_LOOKAT_OBJECT: GetObjectPos(targetid, x, y, z);
+        case E_LOOKAT_ACTOR: GetActorPos(targetid, x, y, z);
+        default: return false;
     }
-    return false;
+    return IsPointLookingAtPoint(playerid, x, y, z, range);
 }


### PR DESCRIPTION
It's ideal not to create definers when the matrix is not used, as this reduces the size of the AMX.

A verification function that was incorrect has been fixed. Since it was declared as stock and not being used, the compiler did not flag the error, but it has now been corrected.

Functions that should not be exposed from the include file have been removed—in this case, they should be static. If a developer wishes to make use of these functions, they simply need to remove the static keyword from the beginning of the declaration.